### PR TITLE
removed duplicate vif 0x00 for VIF_ENERGY,

### DIFF
--- a/src/vif/fbVifs.ts
+++ b/src/vif/fbVifs.ts
@@ -4,14 +4,6 @@ import type { VIFDescriptor } from "@/types";
 export const fbVifs: VIFDescriptor[] = [
   {
     vif: 0x00,
-    legacyName: "VIF_ENERGY_WATT",
-    unit: "Wh",
-    description: "Energy",
-    calc: (val) => divide(val, 1000),
-    apply: applyNumberDefault,
-  },
-  {
-    vif: 0x00,
     legacyName: "VIF_ENERGY_MWH",
     unit: "MWh",
     description: "Energy",


### PR DESCRIPTION
There was a bug in the fbVifs.ts configuration file, where the  first vif was duplicate.  Probably due to copying from the default VIFs. 
 `  {
    vif: 0x00,
    legacyName: "VIF_ENERGY_WATT",
    unit: "Wh",
    description: "Energy",
    calc: (val) => divide(val, 1000),
    apply: applyNumberDefault,
  },` 

